### PR TITLE
Fix setup error from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - python=3.8
 - pytorch=1.10.1
 - cudatoolkit=11.3
-- torchvision=0.11
+- torchvision=0.11.2
 - pip
 - pip:
   - llcv==0.0.9

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - python=3.8
 - pytorch=1.10.1
 - cudatoolkit=11.3
-- torchvision
+- torchvision=0.11
 - pip
 - pip:
   - llcv==0.0.9


### PR DESCRIPTION
Torchvision's version is loose, while torch=1.10.1, causing a potentially incompatible torchvision version.
Setup fails when following the main README's instructions, on env create, when torchvision != 0.11.*
Fixed by specifying torchvision to 0.11.2, the latest recommended for python=3.8, torch=1.10.*, cudatoolkit=11.3
as from: https://pytorch.org/get-started/previous-versions/#v1101

some people (me) have too much time :D